### PR TITLE
Corrected example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ What if you want to change content like add a header? No need for a separate
 filter, just chage the content.
 
     tap(function(file) {
-        file.content = Buffer.concat([
+        file.contents = Buffer.concat([
             new Buffer('HEADER'),
-            file.content
+            file.contents
         ]);
     });
 


### PR DESCRIPTION
file.content should be file.contents
