### PR TITLE
Change the dependency from event-stream to through

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/geejs/gulp-tap",
   "dependencies": {
-    "event-stream": "~3.1.0"
+    "through": "^2.3.8"
   }
 }

--- a/src/tap.coffee
+++ b/src/tap.coffee
@@ -1,4 +1,4 @@
-ES = require('event-stream')
+through = require('through')
 baseStream = require('stream')
 
 DEBUG = process.env.NODE_ENV is 'development'
@@ -54,5 +54,5 @@ module.exports = (lambda) ->
     # passthrough if user returned a stream
     this.emit('data', inst.file) unless obj instanceof baseStream
 
-  return ES.through(modifyFile)
+  return through(modifyFile)
 


### PR DESCRIPTION
Hello

This library uses event-stream but the API it actually uses is only `ES.through`. `ES.through` is just a proxy of `through` npm pacakge and other packages in ES dependencies are unnecessary. This patch changes it to depends directly on `through`.

Thanks,
